### PR TITLE
Fix AddObject - allow to pass None as NULL

### DIFF
--- a/rtapi/__init__.py
+++ b/rtapi/__init__.py
@@ -142,7 +142,14 @@ class RTObject:
 
     def AddObject(self, name, server_type_id, asset_no, label):
         """Add new object to racktables"""
-        sql = "INSERT INTO Object (name,objtype_id,asset_no,label) VALUES ('%s',%d,'%s','%s')" % (name, server_type_id, asset_no, label)
+        if asset_no and label:
+          sql = "INSERT INTO Object (name,objtype_id,asset_no,label) VALUES ('%s',%d,'%s','%s')" % (name, server_type_id, asset_no, label)
+        elif asset_no:
+          sql = "INSERT INTO Object (name,objtype_id,asset_no,label) VALUES ('%s',%d,'%s',NULL)" % (name, server_type_id, asset_no)
+        elif label:
+          sql = "INSERT INTO Object (name,objtype_id,asset_no,label) VALUES ('%s',%d,NULL,'%s')" % (name, server_type_id, label)
+        else:
+          sql = "INSERT INTO Object (name,objtype_id,asset_no,label) VALUES ('%s',%d,NULL,NULL)" % (name, server_type_id)
         self.db_insert(sql)
         return self.db_fetch_lastid()
 


### PR DESCRIPTION
When using AddObject without asset_no (doesn't matter if None or 'NULL'), it will try to pass it in quotes (e.g. 'None'), which will work for one object, but fail for second one because of duplicate entry.
So I've added option to pass NULL which RT internally uses. Same for Label.